### PR TITLE
libx265: Disable assembly for arm

### DIFF
--- a/packages/libx265/build.sh
+++ b/packages/libx265/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="H.265/HEVC video stream encoder library"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.5
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://bitbucket.org/multicoreware/x265_git/downloads/x265_$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=e70a3335cacacbba0b3a20ec6fecd6783932288ebc8163ad74bcc9606477cae8
 TERMUX_PKG_DEPENDS="libc++"
@@ -27,6 +28,8 @@ termux_step_pre_configure() {
 	elif [ "$TERMUX_ARCH" = arm ]; then
 		# Follow termux_step_setup_toolchain.sh
 		ARM_ARGS+=" -march=armv7-a -mfpu=neon -mfloat-abi=softfp -mthumb"
+		# Avoid text relocations.
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DENABLE_ASSEMBLY=OFF"
 	fi
 
 	TERMUX_PKG_SRCDIR="$TERMUX_PKG_SRCDIR/source"


### PR DESCRIPTION
To avoid text relocations.

Fixes #7586.